### PR TITLE
Load admin transactions from BigQuery

### DIFF
--- a/functions/bigquery/transactions_admin_v1.sql
+++ b/functions/bigquery/transactions_admin_v1.sql
@@ -1,22 +1,37 @@
--- Production admin transaction projection.
--- Deploy with:
+-- Admin transaction projection.
+-- Production deploy:
 -- bq query --use_legacy_sql=false < functions/bigquery/transactions_admin_v1.sql
 CREATE OR REPLACE VIEW `reelx-backend.firestore_export.transactions_admin_v1` AS
 SELECT
   document_id AS id,
   timestamp AS export_timestamp,
-  TIMESTAMP_MICROS(
-    SAFE_CAST(JSON_VALUE(data, '$.createdAt._seconds') AS INT64) * 1000000
-    + DIV(
-      COALESCE(SAFE_CAST(JSON_VALUE(data, '$.createdAt._nanoseconds') AS INT64), 0),
-      1000
-    )
+  COALESCE(
+    TIMESTAMP_MICROS(
+      SAFE_CAST(JSON_VALUE(data, '$.createdAt._seconds') AS INT64) * 1000000
+      + DIV(
+        COALESCE(SAFE_CAST(JSON_VALUE(data, '$.createdAt._nanoseconds') AS INT64), 0),
+        1000
+      )
+    ),
+    SAFE_CAST(JSON_VALUE(data, '$.createdAt') AS TIMESTAMP),
+    timestamp
   ) AS created_at,
-  COALESCE(JSON_VALUE(data, '$.pin'), document_id) AS transaction_id,
+  COALESCE(
+    JSON_VALUE(data, '$.pin'),
+    JSON_VALUE(data, '$.transactionId'),
+    document_id
+  ) AS transaction_id,
   COALESCE(JSON_VALUE(data, '$.vendorName'), 'Unknown Vendor') AS vendor_name,
-  SAFE_CAST(JSON_VALUE(data, '$.totalAmount') AS FLOAT64) AS total_amount,
-  COALESCE(JSON_VALUE(data, '$.type'), 'N/A') AS type,
-  SAFE_CAST(JSON_VALUE(data, '$.cashbackAmount') AS FLOAT64) AS cashback_amount,
+  COALESCE(
+    SAFE_CAST(JSON_VALUE(data, '$.totalAmount') AS FLOAT64),
+    SAFE_CAST(JSON_VALUE(data, '$.amount') AS FLOAT64),
+    0
+  ) AS total_amount,
+  COALESCE(JSON_VALUE(data, '$.type'), 'transaction') AS type,
+  COALESCE(
+    SAFE_CAST(JSON_VALUE(data, '$.cashbackAmount') AS FLOAT64),
+    SAFE_CAST(JSON_VALUE(data, '$.cashback') AS FLOAT64)
+  ) AS cashback_amount,
   SAFE_CAST(JSON_VALUE(data, '$.creatorCashbackAmount') AS FLOAT64) AS creator_cashback_amount,
   JSON_VALUE(data, '$.creatorCode') AS creator_code,
   JSON_VALUE(data, '$.creatorCodeOwnerId') AS creator_code_owner_id,
@@ -25,7 +40,11 @@ SELECT
   JSON_VALUE(data, '$.discountCode') AS discount_code,
   JSON_VALUE(data, '$.discountType') AS discount_type,
   SAFE_CAST(JSON_VALUE(data, '$.discountValue') AS FLOAT64) AS discount_value,
-  SAFE_CAST(JSON_VALUE(data, '$.finalAmount') AS FLOAT64) AS final_amount,
+  COALESCE(
+    SAFE_CAST(JSON_VALUE(data, '$.finalAmount') AS FLOAT64),
+    SAFE_CAST(JSON_VALUE(data, '$.totalAmount') AS FLOAT64),
+    SAFE_CAST(JSON_VALUE(data, '$.amount') AS FLOAT64)
+  ) AS final_amount,
   JSON_VALUE(data, '$.purchaseUrl') AS purchase_url,
   JSON_VALUE(data, '$.offerId') AS offer_id,
   JSON_VALUE(data, '$.pin') AS pin,

--- a/functions/src/admin-bigquery-transactions.ts
+++ b/functions/src/admin-bigquery-transactions.ts
@@ -4,15 +4,17 @@ import * as logger from "firebase-functions/logger";
 
 /* eslint-disable require-jsdoc, max-len */
 
-const PROJECT_ID = "reelx-backend";
+const PROJECT_ID =
+  process.env.GCLOUD_PROJECT ||
+  process.env.GCP_PROJECT ||
+  "reelx-backend";
 const LOCATION = "US";
-const VIEW = "`reelx-backend.firestore_export.transactions_admin_v1`";
+const VIEW = `\`${PROJECT_ID}.firestore_export.transactions_admin_v1\``;
 const DEFAULT_PAGE_SIZE = 10;
 const MAX_PAGE_SIZE = 100;
 const DEFAULT_MAXIMUM_BYTES_BILLED = 256 * 1024 * 1024;
 
 const bigquery = new BigQuery({projectId: PROJECT_ID});
-
 const SORTS = {
   date_asc: {
     column: "sort_created_at",
@@ -197,7 +199,9 @@ export async function listAdminBigQueryTransactionsHandler(
   const types: Record<string, string> = {
     limit: "INT64",
   };
-  const where = [];
+  const where = [
+    "DATE(sort_created_at) >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 MONTH)",
+  ];
 
   if (vendorName) {
     where.push("vendor_name = @vendorName");

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -29,7 +29,14 @@ initializeApp();
 setGlobalOptions({maxInstances: 10});
 
 const REGION = "me-central1";
-const STORAGE_BUCKET = "reelx-backend";
+const PROJECT_ID =
+  process.env.GCLOUD_PROJECT ||
+  process.env.GCP_PROJECT ||
+  "reelx-backend";
+const STORAGE_BUCKET =
+  PROJECT_ID === "realx-dev" ?
+    "realx-dev.firebasestorage.app" :
+    "reelx-backend";
 const WEBP_QUALITY = 80;
 const WEBP_CONVERTED_METADATA_KEY = "convertedToWebp";
 const PUBLIC_IMAGE_PATHS = [
@@ -67,11 +74,10 @@ export const listAdminBigQueryTransactions = onCall(
     cors: true,
     timeoutSeconds: 60,
     serviceAccount:
-      "admin-bigquery-transactions@reelx-backend.iam.gserviceaccount.com",
+      "admin-bigquery-transactions@realx-dev.iam.gserviceaccount.com",
   },
   listAdminBigQueryTransactionsHandler,
 );
-
 /**
  * Convert newly uploaded public media images to WebP in place.
  * Existing object paths and Firebase download tokens remain unchanged.

--- a/src/routes/admin/transactions/index.lazy.tsx
+++ b/src/routes/admin/transactions/index.lazy.tsx
@@ -57,37 +57,58 @@ function SortIcon({ field }: { field: 'date' | 'amount' | 'vendor' }) {
 }
 
 function RouteComponent() {
-    const { page, pageSize, vendorName, sort } = useSearch({ from: '/admin/transactions/' })
-    const navigate = useNavigate({ from: '/admin/transactions/' })
-    const queryClient = useQueryClient()
-    const [selectedTransactionId, setSelectedTransactionId] = useState<string | null>(null)
-    const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+const { page, pageSize, vendorName, sort, cursor, history } =
+    useSearch({ from: '/admin/transactions/' })
+
+const navigate = useNavigate({ from: '/admin/transactions/' })
+const queryClient = useQueryClient()
+
+const [selectedTransactionId, setSelectedTransactionId] =
+    useState<string | null>(null)
+
+const [deleteDialogOpen, setDeleteDialogOpen] =
+    useState(false)
 
     const { data, isLoading: isQueryLoading } = useQuery({
-        queryKey: ['transactions-list', page, pageSize, vendorName, sort],
-        queryFn: () => fetchTransactions(page, pageSize, vendorName, sort),
+        queryKey: ['transactions-list', pageSize, vendorName, sort, cursor],
+        queryFn: () => fetchTransactions(pageSize, vendorName, sort, cursor),
         staleTime: STALE_TIME.MEDIUM,
     })
 
     const transactionList = data?.transactions || []
-    const totalTransactions = data?.totalCount || 0
     const loading = isQueryLoading
-
-    const hasNextPage = page * pageSize < totalTransactions
+    const hasNextPage = Boolean(data?.nextCursor)
     const hasPrevPage = page > 1
     const selectedTransaction = transactionList.find((tx) => tx.id === selectedTransactionId) ?? null
     const selectedTransactionLabel = selectedTransaction?.pin || selectedTransaction?.transactionId || selectedTransaction?.id || ''
 
     const updateSearch = (updates: Partial<TransactionSearch>) => {
+        const nextSearch: TransactionSearch = {
+            page: 1,
+            pageSize,
+        }
+
+        const nextVendorName = Object.hasOwn(updates, 'vendorName')
+            ? updates.vendorName
+            : vendorName
+
+        const nextSort = Object.hasOwn(updates, 'sort')
+            ? updates.sort
+            : sort
+
+        if (nextVendorName) nextSearch.vendorName = nextVendorName
+        if (nextSort) nextSearch.sort = nextSort
+
         navigate({
             to: '/admin/transactions',
-            search: { page: 1, pageSize, vendorName, sort, ...updates },
+            search: nextSearch,
         })
     }
 
     const toggleSort = (field: 'date' | 'amount' | 'vendor') => {
         const currentSort = sort as SortOption | undefined
         let newSort: SortOption
+
         if (!currentSort || !currentSort.startsWith(field)) {
             newSort = `${field}_desc` as SortOption
         } else if (currentSort.endsWith('desc')) {
@@ -95,8 +116,10 @@ function RouteComponent() {
         } else {
             newSort = `${field}_desc` as SortOption
         }
+
         updateSearch({ sort: newSort })
     }
+
 
     useEffect(() => {
         if (selectedTransactionId && !transactionList.some((tx) => tx.id === selectedTransactionId)) {
@@ -146,6 +169,7 @@ function RouteComponent() {
         if (!selectedTransactionId) return
         deleteTransactionMutation.mutate(selectedTransactionId)
     }
+
 
     return (
         <div className="p-8 space-y-6 w-full max-w-[1600px] mx-auto">
@@ -470,47 +494,64 @@ function RouteComponent() {
             {/* Pagination */}
             {(hasPrevPage || hasNextPage) && (
                 <div className="flex items-center justify-center gap-4 pt-4">
-                    <Link
-                        from="/admin/transactions/"
-                        search={(prev: TransactionSearch) => ({
-                            ...prev,
-                            page: Math.max(1, page - 1),
-                        })}
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-10 w-auto px-4 gap-2 text-sm font-medium"
                         disabled={!hasPrevPage}
-                        className={!hasPrevPage ? 'pointer-events-none opacity-50' : ''}
+                        onClick={() => {
+                            const cursorHistory = history ? history.split('.') : []
+                            const previous = cursorHistory.pop()
+                            const previousSearch: TransactionSearch = {
+                                page: Math.max(1, page - 1),
+                                pageSize,
+                            }
+
+                            if (vendorName) previousSearch.vendorName = vendorName
+                            if (sort) previousSearch.sort = sort
+                            if (previous && previous !== 'first') previousSearch.cursor = previous
+                            if (cursorHistory.length) previousSearch.history = cursorHistory.join('.')
+
+                            navigate({
+                                to: '/admin/transactions',
+                                search: previousSearch,
+                            })
+                        }}
                     >
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-10 w-auto px-4 gap-2 text-sm font-medium"
-                            disabled={!hasPrevPage}
-                        >
-                            ‹ Previous
-                        </Button>
-                    </Link>
+                        ‹ Previous
+                    </Button>
 
                     <div className="text-sm font-medium text-muted-foreground">
                         Page {page}
                     </div>
 
-                    <Link
-                        from="/admin/transactions/"
-                        search={(prev: TransactionSearch) => ({
-                            ...prev,
-                            page: page + 1,
-                        })}
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-10 w-auto px-4 gap-2 text-sm font-medium"
                         disabled={!hasNextPage}
-                        className={!hasNextPage ? 'pointer-events-none opacity-50' : ''}
+                        onClick={() => {
+                            if (!data?.nextCursor) return
+
+                            const cursorHistory = history ? history.split('.') : []
+                            const nextSearch: TransactionSearch = {
+                                page: page + 1,
+                                pageSize,
+                                cursor: data.nextCursor,
+                                history: [...cursorHistory, cursor || 'first'].join('.'),
+                            }
+
+                            if (vendorName) nextSearch.vendorName = vendorName
+                            if (sort) nextSearch.sort = sort
+
+                            navigate({
+                                to: '/admin/transactions',
+                                search: nextSearch,
+                            })
+                        }}
                     >
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-10 w-auto px-4 gap-2 text-sm font-medium"
-                            disabled={!hasNextPage}
-                        >
-                            Next ›
-                        </Button>
-                    </Link>
+                        Next ›
+                    </Button>
                 </div>
             )}
         </div>

--- a/src/routes/admin/transactions/index.tsx
+++ b/src/routes/admin/transactions/index.tsx
@@ -1,34 +1,21 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { httpsCallable } from 'firebase/functions'
 import { z } from 'zod'
-import { db } from '@/firebase/config'
-import {
-    collection, query, orderBy, where,
-    getCountFromServer,
-    type QueryConstraint,
-} from 'firebase/firestore'
-import { formatTimestamp } from '@/lib/format-timestamp'
-import { logAdminRead } from '@/lib/admin-read-logging'
-import { getCursorPage } from '@/lib/firestore-pagination'
+import { functions } from '@/firebase/config'
+
+const sortSchema = z.enum(['date_asc', 'date_desc', 'amount_asc', 'amount_desc', 'vendor_asc', 'vendor_desc'])
 
 const transactionsSearchSchema = z.object({
     pageSize: z.number().catch(10),
     page: z.number().catch(1),
     vendorName: z.string().optional().catch(undefined),
-    sort: z.enum(['date_asc', 'date_desc', 'amount_asc', 'amount_desc', 'vendor_asc', 'vendor_desc']).optional().catch(undefined),
+    sort: sortSchema.optional().catch(undefined),
+    cursor: z.string().optional().catch(undefined),
+    history: z.string().optional().catch(undefined),
 })
 
 export type TransactionSearch = z.infer<typeof transactionsSearchSchema>
-
-export const Route = createFileRoute('/admin/transactions/')({
-    validateSearch: (search) => transactionsSearchSchema.parse(search),
-    loaderDeps: ({ search: { page, pageSize, vendorName, sort } }) => ({ page, pageSize, vendorName, sort }),
-    loader: async ({ context: { queryClient }, deps: { page, pageSize, vendorName, sort } }) => {
-        await queryClient.ensureQueryData({
-            queryKey: ['transactions-list', page, pageSize, vendorName, sort],
-            queryFn: () => fetchTransactions(page, pageSize, vendorName, sort),
-        })
-    },
-})
+type SortOption = z.infer<typeof sortSchema>
 
 export interface Transaction {
     id: string
@@ -45,82 +32,84 @@ export interface Transaction {
     creatorCodeOwnerId?: string | null
     creatorUid?: string | null
     discountAmount?: number
-    discountCode?: string
-    discountType?: string
+    discountCode?: string | null
+    discountType?: string | null
     discountValue?: number
     finalAmount?: number
-    purchaseUrl?: string
-    offerId?: string
-    pin?: string
-    userId?: string
-    vendorId?: string
+    purchaseUrl?: string | null
+    offerId?: string | null
+    pin?: string | null
+    userId?: string | null
+    vendorId?: string | null
     redemptionCardAmount?: number
     remainingAmount?: number
 }
 
-type SortOption = 'date_asc' | 'date_desc' | 'amount_asc' | 'amount_desc' | 'vendor_asc' | 'vendor_desc'
+interface BigQueryTransactionResult {
+    transactions: Transaction[]
+    nextCursor: string | null
+    query: {
+        durationMs: number
+        bytesProcessed: number
+        bytesBilled: number
+        cacheHit: boolean
+    }
+    freshness: string | null
+}
 
-function getOrderBy(sort?: SortOption): { field: string; dir: 'asc' | 'desc' } {
-    switch (sort) {
-        case 'date_asc': return { field: 'createdAt', dir: 'asc' }
-        case 'amount_asc': return { field: 'totalAmount', dir: 'asc' }
-        case 'amount_desc': return { field: 'totalAmount', dir: 'desc' }
-        case 'vendor_asc': return { field: 'vendorName', dir: 'asc' }
-        case 'vendor_desc': return { field: 'vendorName', dir: 'desc' }
-        default: return { field: 'createdAt', dir: 'desc' }
+export async function fetchTransactions(
+    pageSize: number,
+    vendorName?: string,
+    sort?: SortOption,
+    cursor?: string,
+) {
+    const request: {
+        pageSize: number
+        vendorName?: string
+        sort?: SortOption
+        cursor?: string
+    } = { pageSize }
+
+    if (vendorName) request.vendorName = vendorName
+    if (sort) request.sort = sort
+    if (cursor) request.cursor = cursor
+
+    const callable = httpsCallable<
+        { pageSize: number; vendorName?: string; sort?: SortOption; cursor?: string },
+        BigQueryTransactionResult
+    >(functions, 'listAdminBigQueryTransactions')
+
+    const result = await callable(request)
+
+    return {
+        ...result.data,
+        transactions: result.data.transactions.map((transaction) => {
+            const date = transaction.rawDate ? new Date(transaction.rawDate) : null
+            const totalAmountNum = transaction.totalAmountNum || 0
+
+            return {
+                ...transaction,
+                date: date && !Number.isNaN(date.getTime()) ? date.toLocaleString() : 'Unknown Date',
+                totalAmount: `QAR ${totalAmountNum}`,
+                cashbackAmount: transaction.cashbackAmount ?? undefined,
+                creatorCashbackAmount: transaction.creatorCashbackAmount ?? undefined,
+                discountAmount: transaction.discountAmount ?? undefined,
+                discountValue: transaction.discountValue ?? undefined,
+                finalAmount: transaction.finalAmount ?? undefined,
+                redemptionCardAmount: transaction.redemptionCardAmount ?? undefined,
+                remainingAmount: transaction.remainingAmount ?? undefined,
+            }
+        }),
     }
 }
 
-export async function fetchTransactions(page: number, pageSize: number, vendorName?: string, sort?: SortOption) {
-    const collRef = collection(db, 'transactions')
-    const { field, dir } = getOrderBy(sort)
-
-    // Build base constraints
-    const baseConstraints: QueryConstraint[] = [orderBy(field, dir)]
-    if (vendorName) {
-        baseConstraints.push(where('vendorName', '==', vendorName))
-    }
-
-    // Get total count (1 read via aggregation)
-    const countConstraints: QueryConstraint[] = []
-    if (vendorName) countConstraints.push(where('vendorName', '==', vendorName))
-    const countSnap = await getCountFromServer(query(collRef, ...countConstraints))
-    const totalCount = countSnap.data().count
-
-    const pageResult = await getCursorPage(
-        collRef,
-        baseConstraints,
-        page,
-        pageSize,
-        `transactions:${vendorName || 'all'}:${sort || 'date_desc'}`,
-    )
-
-    const transactions = pageResult.docs.map((docSnap) => {
-        const data = docSnap.data()
-        const dateValue = formatTimestamp(data.createdAt)
-
-        return {
-            id: docSnap.id,
-            ...data,
-            date: dateValue.toLocaleString() || 'Unknown Date',
-            rawDate: dateValue.toISOString(),
-            transactionId: data.pin || docSnap.id,
-            vendorName: data.vendorName || 'Unknown Vendor',
-            totalAmount: data.totalAmount ? `QAR ${data.totalAmount}` : 'QAR 0',
-            totalAmountNum: data.totalAmount || 0,
-            type: data.type || 'N/A',
-        } as Transaction
-    })
-
-    logAdminRead('transactions-page', {
-        page,
-        pageSize,
-        docsFetched: pageResult.docsFetched,
-        docsDisplayed: transactions.length,
-        totalCount,
-        vendorName: vendorName || null,
-        sort: sort || 'date_desc',
-    })
-
-    return { transactions, totalCount }
-}
+export const Route = createFileRoute('/admin/transactions/')({
+    validateSearch: (search) => transactionsSearchSchema.parse(search),
+    loaderDeps: ({ search: { pageSize, vendorName, sort, cursor } }) => ({ pageSize, vendorName, sort, cursor }),
+    loader: async ({ context: { queryClient }, deps: { pageSize, vendorName, sort, cursor } }) => {
+        await queryClient.ensureQueryData({
+            queryKey: ['transactions-list', pageSize, vendorName, sort, cursor],
+            queryFn: () => fetchTransactions(pageSize, vendorName, sort, cursor),
+        })
+    },
+})


### PR DESCRIPTION
Implemented the admin transactions migration to BigQuery.

* Admin transactions table now loads data from BigQuery through a Cloud Function.
* Query is limited to transactions from the last month.
* Sorting, filtering, and pagination are handled through the BigQuery endpoint.
* Clicking a transaction still opens the existing Firestore-backed transaction details page.
* Deployed and tested on realx-dev.
* Verified frontend build, functions build, and linting successfully.
