### PR TITLE
Redesign vendor panel with customizable themes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -22,6 +22,36 @@ function isValidOwnerProfileUpdate() {
   && request.resource.data.updatedAt is timestamp;
 }
 
+function isValidVendorDashboardTheme() {
+  return request.resource.data.keys().hasOnly([
+    'primaryColor',
+    'accentColor',
+    'backgroundColor',
+    'cardColor',
+    'chartColor',
+    'updatedAt'
+  ])
+  && request.resource.data.keys().hasAll([
+    'primaryColor',
+    'accentColor',
+    'backgroundColor',
+    'cardColor',
+    'chartColor',
+    'updatedAt'
+  ])
+  && request.resource.data.primaryColor is string
+  && request.resource.data.primaryColor.matches('^#[0-9A-Fa-f]{6}$')
+  && request.resource.data.accentColor is string
+  && request.resource.data.accentColor.matches('^#[0-9A-Fa-f]{6}$')
+  && request.resource.data.backgroundColor is string
+  && request.resource.data.backgroundColor.matches('^#[0-9A-Fa-f]{6}$')
+  && request.resource.data.cardColor is string
+  && request.resource.data.cardColor.matches('^#[0-9A-Fa-f]{6}$')
+  && request.resource.data.chartColor is string
+  && request.resource.data.chartColor.matches('^#[0-9A-Fa-f]{6}$')
+  && request.resource.data.updatedAt is timestamp;
+}
+
 function isValidSavedOffer() {
   return request.resource.data.keys().hasOnly([
       'type',
@@ -164,6 +194,18 @@ match /events/{eventId} {
 match /vendors/{vendorId} {
   allow read: if true;
   allow write: if isAdmin();
+}
+
+// ─── vendor dashboard customization ──────────────────────────────────
+match /vendorDashboardThemes/{vendorId} {
+  allow read: if request.auth != null
+    && (request.auth.uid == vendorId || isAdmin());
+
+  allow create, update: if request.auth != null
+    && ((request.auth.uid == vendorId && isValidVendorDashboardTheme()) || isAdmin());
+
+  allow delete: if request.auth != null
+    && (request.auth.uid == vendorId || isAdmin());
 }
 
 // ─── holding groups ──────────────────────────────────────────────────

--- a/src/lib/vendor-dashboard-theme.ts
+++ b/src/lib/vendor-dashboard-theme.ts
@@ -1,0 +1,129 @@
+import { queryOptions } from '@tanstack/react-query'
+import { doc, getDoc } from 'firebase/firestore'
+import { db } from '@/firebase/config'
+
+export interface VendorDashboardTheme {
+  primaryColor: string
+  accentColor: string
+  backgroundColor: string
+  cardColor: string
+  chartColor: string
+}
+
+export interface VendorDashboardPalette {
+  name: string
+  description: string
+  theme: VendorDashboardTheme
+}
+
+export const DEFAULT_VENDOR_DASHBOARD_THEME: VendorDashboardTheme = {
+  primaryColor: '#16A34A',
+  accentColor: '#22C55E',
+  backgroundColor: '#F6FBF7',
+  cardColor: '#FFFFFF',
+  chartColor: '#16A34A',
+}
+
+export const VENDOR_DASHBOARD_PALETTES: ReadonlyArray<VendorDashboardPalette> = [
+  {
+    name: 'RealX Green',
+    description: 'Fresh and familiar',
+    theme: DEFAULT_VENDOR_DASHBOARD_THEME,
+  },
+  {
+    name: 'Ocean Blue',
+    description: 'Clear and professional',
+    theme: {
+      primaryColor: '#2563EB',
+      accentColor: '#0EA5E9',
+      backgroundColor: '#F5F9FF',
+      cardColor: '#FFFFFF',
+      chartColor: '#2563EB',
+    },
+  },
+  {
+    name: 'Royal Violet',
+    description: 'Bold and premium',
+    theme: {
+      primaryColor: '#7C3AED',
+      accentColor: '#A855F7',
+      backgroundColor: '#FAF7FF',
+      cardColor: '#FFFFFF',
+      chartColor: '#7C3AED',
+    },
+  },
+  {
+    name: 'Sunset Orange',
+    description: 'Warm and energetic',
+    theme: {
+      primaryColor: '#EA580C',
+      accentColor: '#F59E0B',
+      backgroundColor: '#FFF8F2',
+      cardColor: '#FFFFFF',
+      chartColor: '#EA580C',
+    },
+  },
+  {
+    name: 'Rose',
+    description: 'Modern and expressive',
+    theme: {
+      primaryColor: '#E11D48',
+      accentColor: '#FB7185',
+      backgroundColor: '#FFF7F8',
+      cardColor: '#FFFFFF',
+      chartColor: '#E11D48',
+    },
+  },
+  {
+    name: 'Slate',
+    description: 'Neutral and focused',
+    theme: {
+      primaryColor: '#334155',
+      accentColor: '#64748B',
+      backgroundColor: '#F8FAFC',
+      cardColor: '#FFFFFF',
+      chartColor: '#475569',
+    },
+  },
+]
+
+const HEX_COLOR_PATTERN = /^#[0-9A-F]{6}$/i
+
+export function isHexColor(value: unknown): value is string {
+  return typeof value === 'string' && HEX_COLOR_PATTERN.test(value)
+}
+
+function normalizeTheme(data: Partial<VendorDashboardTheme>): VendorDashboardTheme {
+  return {
+    primaryColor: isHexColor(data.primaryColor)
+      ? data.primaryColor.toUpperCase()
+      : DEFAULT_VENDOR_DASHBOARD_THEME.primaryColor,
+    accentColor: isHexColor(data.accentColor)
+      ? data.accentColor.toUpperCase()
+      : DEFAULT_VENDOR_DASHBOARD_THEME.accentColor,
+    backgroundColor: isHexColor(data.backgroundColor)
+      ? data.backgroundColor.toUpperCase()
+      : DEFAULT_VENDOR_DASHBOARD_THEME.backgroundColor,
+    cardColor: isHexColor(data.cardColor)
+      ? data.cardColor.toUpperCase()
+      : DEFAULT_VENDOR_DASHBOARD_THEME.cardColor,
+    chartColor: isHexColor(data.chartColor)
+      ? data.chartColor.toUpperCase()
+      : DEFAULT_VENDOR_DASHBOARD_THEME.chartColor,
+  }
+}
+
+export const vendorDashboardThemeQueryOptions = (vendorId: string) =>
+  queryOptions({
+    queryKey: ['vendor-dashboard-theme', vendorId],
+    queryFn: async () => {
+      if (!vendorId) return DEFAULT_VENDOR_DASHBOARD_THEME
+
+      const snapshot = await getDoc(doc(db, 'vendorDashboardThemes', vendorId))
+      if (!snapshot.exists()) return DEFAULT_VENDOR_DASHBOARD_THEME
+
+      return normalizeTheme(snapshot.data() as Partial<VendorDashboardTheme>)
+    },
+    enabled: Boolean(vendorId),
+    staleTime: 5 * 60 * 1000,
+  })

--- a/src/routes/(vendor-panel)/_vendor.campaign.tsx
+++ b/src/routes/(vendor-panel)/_vendor.campaign.tsx
@@ -1,50 +1,327 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { vendorQueryOptions } from '@/queries'
+import {
+  ArrowUpRight,
+  BadgePercent,
+  Gift,
+  Loader2,
+  Sparkles,
+  Store,
+  TicketCheck,
+} from 'lucide-react'
 import { useAuth } from '@/auth'
-import { Loader2 } from 'lucide-react'
+import { vendorQueryOptions, type EmbeddedOffer } from '@/queries'
+import { vendorDashboardThemeQueryOptions } from '@/lib/vendor-dashboard-theme'
 
 export const Route = createFileRoute('/(vendor-panel)/_vendor/campaign')({
   component: VendorCampaign,
 })
 
+function withAlpha(hexColor: string, alpha: number) {
+  const hex = hexColor.replace('#', '')
+  if (!/^[0-9A-Fa-f]{6}$/.test(hex)) return `rgba(15, 23, 42, ${alpha})`
+
+  const red = Number.parseInt(hex.slice(0, 2), 16)
+  const green = Number.parseInt(hex.slice(2, 4), 16)
+  const blue = Number.parseInt(hex.slice(4, 6), 16)
+
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+}
+
+function formatDiscount(offer: EmbeddedOffer) {
+  switch (offer.discountType) {
+    case 'buy1get1':
+      return 'Buy 1 Get 1'
+    case 'percentage':
+      return `${offer.discountValue || 0}% OFF`
+    case 'amount':
+      return `QAR ${offer.discountValue || 0} OFF`
+    default:
+      return 'Special offer'
+  }
+}
+
 function VendorCampaign() {
   const { user } = useAuth()
   const vendorId = user?.uid || ''
 
-  const { data: vendor, isLoading } = useQuery(vendorQueryOptions(vendorId))
-  const offers = vendor?.offers || []
+  const { data: vendor, isLoading: vendorLoading } = useQuery(vendorQueryOptions(vendorId))
+  const { data: theme, isLoading: themeLoading } = useQuery(
+    vendorDashboardThemeQueryOptions(vendorId),
+  )
 
-  if (isLoading) {
-    return <div className="flex justify-center items-center h-64"><Loader2 className="animate-spin" /></div>
+  if (vendorLoading || themeLoading || !theme) {
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center bg-slate-50">
+        <div className="flex items-center gap-3 rounded-2xl border bg-white px-6 py-4 shadow-sm">
+          <Loader2 className="h-5 w-5 animate-spin text-emerald-500" />
+          <span className="font-medium text-slate-600">Preparing your campaigns...</span>
+        </div>
+      </div>
+    )
   }
 
-  return (
-    <div className="p-6 space-y-6">
-      <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold">Offers</h1>
-      </div>
+  const offers = vendor?.offers || []
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {offers.map((offer, index) => (
-          <div key={index} className="bg-white rounded-xl shadow-sm border overflow-hidden">
-            <div className="p-4 space-y-2">
-              <h3 className="font-semibold text-lg">{offer.titleEn}</h3>
-              <p className="text-sm text-gray-500 line-clamp-2">{offer.descriptionEn}</p>
-              <div className="pt-4 flex justify-between items-center text-sm">
-                <span className="font-medium text-blue-600">
-                  {offer.discountType === 'buy1get1' ? 'Buy 1 Get 1' : offer.discountType === 'percentage' ? `${offer.discountValue}% OFF` : `$${offer.discountValue} OFF`}
-                </span>
-              </div>
+  return (
+    <main
+      className="min-h-full px-4 py-5 transition-colors md:px-6 md:py-7 lg:px-8"
+      style={{ backgroundColor: theme.backgroundColor }}
+    >
+      <div className="mx-auto max-w-7xl space-y-6">
+        <section
+          className="overflow-hidden rounded-3xl border p-5 shadow-sm md:p-7"
+          style={{
+            borderColor: withAlpha(theme.primaryColor, 0.16),
+            background: `linear-gradient(135deg, ${withAlpha(theme.primaryColor, 0.16)} 0%, ${theme.cardColor} 64%, ${withAlpha(theme.accentColor, 0.09)} 100%)`,
+          }}
+        >
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <span
+                className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold"
+                style={{
+                  color: theme.primaryColor,
+                  backgroundColor: withAlpha(theme.primaryColor, 0.1),
+                }}
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                Vendor campaigns
+              </span>
+
+              <h1 className="mt-4 text-3xl font-black tracking-tight text-slate-950 md:text-4xl">
+                Offers & campaigns
+              </h1>
+
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 md:text-base">
+                Review the promotions currently connected to your business and see how
+                each offer is presented to students.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/dashboard"
+                className="inline-flex h-11 items-center gap-2 rounded-xl px-5 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                style={{ backgroundColor: theme.primaryColor }}
+              >
+                Dashboard
+                <ArrowUpRight className="h-4 w-4" />
+              </Link>
+
+              <Link
+                to="/profile"
+                className="inline-flex h-11 items-center gap-2 rounded-xl border bg-white px-5 text-sm font-semibold text-slate-800 transition hover:-translate-y-0.5 hover:shadow-sm"
+                style={{ borderColor: withAlpha(theme.primaryColor, 0.2) }}
+              >
+                View profile
+              </Link>
             </div>
           </div>
-        ))}
-        {offers.length === 0 && (
-          <div className="col-span-full py-12 text-center text-gray-500">
-            No campaigns found. Create your first offer to get started.
+        </section>
+
+        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <article
+            className="flex items-center gap-4 rounded-2xl border p-5 shadow-sm"
+            style={{
+              backgroundColor: theme.cardColor,
+              borderColor: withAlpha(theme.primaryColor, 0.14),
+            }}
+          >
+            <div
+              className="flex h-12 w-12 items-center justify-center rounded-2xl"
+              style={{
+                backgroundColor: withAlpha(theme.accentColor, 0.13),
+                color: theme.primaryColor,
+              }}
+            >
+              <TicketCheck className="h-6 w-6" />
+            </div>
+            <div>
+              <p className="text-2xl font-black text-slate-950">{offers.length}</p>
+              <p className="text-sm font-medium text-slate-500">Published offers</p>
+            </div>
+          </article>
+
+          <article
+            className="flex items-center gap-4 rounded-2xl border p-5 shadow-sm"
+            style={{
+              backgroundColor: theme.cardColor,
+              borderColor: withAlpha(theme.primaryColor, 0.14),
+            }}
+          >
+            <div
+              className="flex h-12 w-12 items-center justify-center rounded-2xl"
+              style={{
+                backgroundColor: withAlpha(theme.primaryColor, 0.11),
+                color: theme.primaryColor,
+              }}
+            >
+              <Store className="h-6 w-6" />
+            </div>
+            <div>
+              <p className="truncate text-lg font-black text-slate-950">
+                {vendor?.name || 'Your business'}
+              </p>
+              <p className="text-sm font-medium text-slate-500">Campaign owner</p>
+            </div>
+          </article>
+        </section>
+
+        <section
+          className="rounded-3xl border p-5 shadow-sm md:p-6"
+          style={{
+            backgroundColor: theme.cardColor,
+            borderColor: withAlpha(theme.primaryColor, 0.14),
+          }}
+        >
+          <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-2xl font-black tracking-tight text-slate-950">
+                Current offers
+              </h2>
+              <p className="mt-1 text-sm text-slate-500">
+                All promotions currently visible from your vendor account.
+              </p>
+            </div>
+
+            {offers.length > 0 && (
+              <span
+                className="w-fit rounded-full px-3 py-1.5 text-xs font-semibold"
+                style={{
+                  color: theme.primaryColor,
+                  backgroundColor: withAlpha(theme.primaryColor, 0.1),
+                }}
+              >
+                {offers.length} {offers.length === 1 ? 'offer' : 'offers'}
+              </span>
+            )}
           </div>
-        )}
+
+          {offers.length > 0 ? (
+            <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+              {offers.map((offer, index) => (
+                <article
+                  key={`${offer.titleEn || 'offer'}-${index}`}
+                  className="group relative overflow-hidden rounded-3xl border p-5 transition hover:-translate-y-1 hover:shadow-lg"
+                  style={{
+                    borderColor: withAlpha(theme.primaryColor, 0.16),
+                    background: `linear-gradient(145deg, ${theme.cardColor} 30%, ${withAlpha(theme.accentColor, 0.08)} 100%)`,
+                  }}
+                >
+                  <div
+                    className="absolute inset-x-0 top-0 h-1.5"
+                    style={{ backgroundColor: theme.primaryColor }}
+                  />
+
+                  <div className="flex items-start justify-between gap-4 pt-1">
+                    <div
+                      className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl"
+                      style={{
+                        backgroundColor: withAlpha(theme.primaryColor, 0.11),
+                        color: theme.primaryColor,
+                      }}
+                    >
+                      {offer.discountType === 'buy1get1' ? (
+                        <Gift className="h-6 w-6" />
+                      ) : (
+                        <BadgePercent className="h-6 w-6" />
+                      )}
+                    </div>
+
+                    <span
+                      className="rounded-full px-3 py-1.5 text-xs font-bold"
+                      style={{
+                        color: theme.primaryColor,
+                        backgroundColor: withAlpha(theme.primaryColor, 0.11),
+                      }}
+                    >
+                      {formatDiscount(offer)}
+                    </span>
+                  </div>
+
+                  <div className="mt-5">
+                    <h3 className="break-words text-xl font-black text-slate-950">
+                      {offer.titleEn || 'Untitled offer'}
+                    </h3>
+
+                    {offer.titleAr && (
+                      <p className="mt-1 text-sm font-semibold text-slate-500" dir="rtl">
+                        {offer.titleAr}
+                      </p>
+                    )}
+
+                    <p className="mt-3 min-h-12 text-sm leading-6 text-slate-600">
+                      {offer.descriptionEn || 'No description has been provided for this offer.'}
+                    </p>
+
+                    {offer.descriptionAr && (
+                      <p className="mt-2 text-sm leading-6 text-slate-500" dir="rtl">
+                        {offer.descriptionAr}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="mt-6 flex items-center justify-between border-t border-slate-200/70 pt-4">
+                    <span className="inline-flex items-center gap-2 text-xs font-semibold text-slate-500">
+                      <span
+                        className="h-2 w-2 rounded-full"
+                        style={{ backgroundColor: theme.accentColor }}
+                      />
+                      Visible to students
+                    </span>
+
+                    <span
+                      className="text-xs font-bold"
+                      style={{ color: theme.primaryColor }}
+                    >
+                      Offer #{index + 1}
+                    </span>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <div
+              className="flex min-h-80 items-center justify-center rounded-3xl border border-dashed px-6 py-12 text-center"
+              style={{
+                borderColor: withAlpha(theme.primaryColor, 0.22),
+                backgroundColor: withAlpha(theme.primaryColor, 0.035),
+              }}
+            >
+              <div className="max-w-md">
+                <div
+                  className="mx-auto flex h-16 w-16 items-center justify-center rounded-3xl"
+                  style={{
+                    color: theme.primaryColor,
+                    backgroundColor: withAlpha(theme.primaryColor, 0.11),
+                  }}
+                >
+                  <Gift className="h-8 w-8" />
+                </div>
+
+                <h3 className="mt-5 text-xl font-black text-slate-950">
+                  No campaigns yet
+                </h3>
+
+                <p className="mt-2 text-sm leading-6 text-slate-500">
+                  Offers added to your vendor account will appear here with their
+                  student-facing titles, descriptions, and discount details.
+                </p>
+
+                <Link
+                  to="/dashboard"
+                  className="mt-6 inline-flex h-11 items-center gap-2 rounded-xl px-5 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                  style={{ backgroundColor: theme.primaryColor }}
+                >
+                  Return to dashboard
+                  <ArrowUpRight className="h-4 w-4" />
+                </Link>
+              </div>
+            </div>
+          )}
+        </section>
       </div>
-    </div>
+    </main>
   )
 }

--- a/src/routes/(vendor-panel)/_vendor.dashboard.tsx
+++ b/src/routes/(vendor-panel)/_vendor.dashboard.tsx
@@ -1,75 +1,636 @@
-﻿import { createFileRoute } from '@tanstack/react-router'
-import { useQuery } from '@tanstack/react-query'
-import { vendorStatsQueryOptions, vendorChartDataQueryOptions, type ChartRange } from '@/queries'
-import { useState } from 'react'
-import { Area, AreaChart, CartesianGrid, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { doc, serverTimestamp, setDoc } from 'firebase/firestore'
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ArrowUpRight,
+  BadgePercent,
+  Clock3,
+  Loader2,
+  Palette,
+  ReceiptText,
+  RotateCcw,
+  Save,
+  Sparkles,
+  Store,
+  TicketCheck,
+  WalletCards,
+} from 'lucide-react'
+import { toast } from 'sonner'
 import { useAuth } from '@/auth'
-import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { db } from '@/firebase/config'
+import {
+  vendorChartDataQueryOptions,
+  vendorQueryOptions,
+  vendorStatsQueryOptions,
+  type ChartRange,
+} from '@/queries'
+import {
+  DEFAULT_VENDOR_DASHBOARD_THEME,
+  VENDOR_DASHBOARD_PALETTES,
+  vendorDashboardThemeQueryOptions,
+  type VendorDashboardTheme,
+} from '@/lib/vendor-dashboard-theme'
 
 export const Route = createFileRoute('/(vendor-panel)/_vendor/dashboard')({
   component: VendorDashboard,
 })
 
+const currencyFormatter = new Intl.NumberFormat('en-QA', {
+  style: 'currency',
+  currency: 'QAR',
+  maximumFractionDigits: 0,
+})
+
+function formatCurrency(value: number | null | undefined) {
+  return currencyFormatter.format(Number(value || 0))
+}
+
+function withAlpha(hex: string, opacity: number) {
+  const alpha = Math.round(Math.min(1, Math.max(0, opacity)) * 255)
+    .toString(16)
+    .padStart(2, '0')
+  return `${hex}${alpha}`
+}
+
+function contrastText(hex: string) {
+  const value = hex.replace('#', '')
+  const red = Number.parseInt(value.slice(0, 2), 16)
+  const green = Number.parseInt(value.slice(2, 4), 16)
+  const blue = Number.parseInt(value.slice(4, 6), 16)
+  const luminance = (red * 299 + green * 587 + blue * 114) / 1000
+  return luminance > 155 ? '#0F172A' : '#FFFFFF'
+}
+
+function formatChartDate(value: string) {
+  return new Date(`${value}T00:00:00`).toLocaleDateString('en-QA', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function themesMatch(first: VendorDashboardTheme, second: VendorDashboardTheme) {
+  return (
+    first.primaryColor === second.primaryColor &&
+    first.accentColor === second.accentColor &&
+    first.backgroundColor === second.backgroundColor &&
+    first.cardColor === second.cardColor &&
+    first.chartColor === second.chartColor
+  )
+}
+
 function VendorDashboard() {
   const { user } = useAuth()
+  const queryClient = useQueryClient()
   const vendorId = user?.uid || ''
   const [range, setRange] = useState<ChartRange>('7d')
+  const [draftTheme, setDraftTheme] = useState<VendorDashboardTheme>(
+    DEFAULT_VENDOR_DASHBOARD_THEME,
+  )
+  const [savedTheme, setSavedTheme] = useState<VendorDashboardTheme>(
+    DEFAULT_VENDOR_DASHBOARD_THEME,
+  )
 
-  const { data: stats, isLoading: statsLoading } = useQuery(vendorStatsQueryOptions(vendorId))
-  const { data: chartData, isLoading: chartLoading } = useQuery(vendorChartDataQueryOptions(vendorId, range))
+  const { data: vendor, isLoading: vendorLoading } = useQuery({
+    ...vendorQueryOptions(vendorId),
+    enabled: Boolean(vendorId),
+  })
+  const { data: stats, isLoading: statsLoading } = useQuery({
+    ...vendorStatsQueryOptions(vendorId),
+    enabled: Boolean(vendorId),
+  })
+  const { data: chartData = [], isLoading: chartLoading } = useQuery({
+    ...vendorChartDataQueryOptions(vendorId, range),
+    enabled: Boolean(vendorId),
+  })
+  const { data: storedTheme, isLoading: themeLoading } = useQuery(
+    vendorDashboardThemeQueryOptions(vendorId),
+  )
 
-  if (statsLoading || chartLoading) {
-    return <div className="flex justify-center items-center h-64"><Loader2 className="animate-spin" /></div>
+  useEffect(() => {
+    if (!storedTheme) return
+    setDraftTheme(storedTheme)
+    setSavedTheme(storedTheme)
+  }, [storedTheme])
+
+  const saveThemeMutation = useMutation({
+    mutationFn: async (theme: VendorDashboardTheme) => {
+      if (!vendorId) throw new Error('Vendor account is not available.')
+
+      await setDoc(
+        doc(db, 'vendorDashboardThemes', vendorId),
+        {
+          ...theme,
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true },
+      )
+
+      return theme
+    },
+    onSuccess: (theme) => {
+      queryClient.setQueryData(['vendor-dashboard-theme', vendorId], theme)
+      setSavedTheme(theme)
+      setDraftTheme(theme)
+      toast.success('Dashboard style saved', {
+        description: 'Your vendor dashboard now uses the selected colors.',
+      })
+    },
+    onError: (error) => {
+      toast.error('Could not save dashboard style', {
+        description:
+          error instanceof Error ? error.message : 'Please try again.',
+      })
+    },
+  })
+
+  const hasUnsavedChanges = useMemo(
+    () => !themesMatch(draftTheme, savedTheme),
+    [draftTheme, savedTheme],
+  )
+
+  const isLoading = vendorLoading || statsLoading || chartLoading || themeLoading
+  const primaryTextColor = contrastText(draftTheme.primaryColor)
+  const cardBorderColor = withAlpha(draftTheme.primaryColor, 0.14)
+  const hasRevenueData = chartData.some((point) => Number(point.revenue) > 0)
+
+  const statCards = [
+    {
+      label: 'Total revenue',
+      value: formatCurrency(stats?.totalRevenue),
+      helper: 'From completed redemptions',
+      icon: WalletCards,
+    },
+    {
+      label: 'Total redemptions',
+      value: String(stats?.totalRedemptions || 0),
+      helper: 'Across all transactions',
+      icon: ReceiptText,
+    },
+    {
+      label: 'Active offers',
+      value: String(stats?.activeOffers || 0),
+      helper: 'Currently visible to students',
+      icon: TicketCheck,
+    },
+    {
+      label: 'Pending transactions',
+      value: String(stats?.pendingTransactions || 0),
+      helper: `${formatCurrency(stats?.totalDiscount)} total discounts`,
+      icon: Clock3,
+    },
+  ]
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex min-h-[calc(100vh-var(--header-height))] items-center justify-center"
+        style={{ backgroundColor: DEFAULT_VENDOR_DASHBOARD_THEME.backgroundColor }}
+      >
+        <div className="flex items-center gap-3 rounded-2xl border bg-white px-5 py-4 shadow-sm">
+          <Loader2 className="h-5 w-5 animate-spin text-brand-green" />
+          <span className="text-sm font-medium text-slate-600">
+            Preparing your dashboard...
+          </span>
+        </div>
+      </div>
+    )
   }
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
-      
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="p-4 bg-white rounded-xl shadow-sm border">
-          <p className="text-sm text-gray-500">Total Revenue</p>
-          <p className="text-2xl font-semibold">${stats?.totalRevenue || 0}</p>
-        </div>
-        <div className="p-4 bg-white rounded-xl shadow-sm border">
-          <p className="text-sm text-gray-500">Total Redemptions</p>
-          <p className="text-2xl font-semibold">{stats?.totalRedemptions || 0}</p>
-        </div>
-        <div className="p-4 bg-white rounded-xl shadow-sm border">
-          <p className="text-sm text-gray-500">Active Offers</p>
-          <p className="text-2xl font-semibold">{stats?.activeOffers || 0}</p>
-        </div>
-        <div className="p-4 bg-white rounded-xl shadow-sm border">
-          <p className="text-sm text-gray-500">Total Discount</p>
-          <p className="text-2xl font-semibold">${stats?.totalDiscount || 0}</p>
-        </div>
-      </div>
+    <div
+      className="min-h-[calc(100vh-var(--header-height))] p-4 transition-colors duration-300 md:p-6 lg:p-8"
+      style={{ backgroundColor: draftTheme.backgroundColor }}
+    >
+      <div className="mx-auto max-w-7xl space-y-6">
+        <section
+          className="relative overflow-hidden rounded-3xl border p-6 shadow-sm md:p-8"
+          style={{
+            background: `linear-gradient(135deg, ${withAlpha(draftTheme.primaryColor, 0.18)}, ${withAlpha(draftTheme.accentColor, 0.11)} 55%, ${draftTheme.cardColor})`,
+            borderColor: cardBorderColor,
+          }}
+        >
+          <div
+            className="absolute -right-16 -top-20 h-56 w-56 rounded-full blur-3xl"
+            style={{ backgroundColor: withAlpha(draftTheme.accentColor, 0.22) }}
+          />
+          <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="max-w-2xl">
+              <div
+                className="mb-4 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold"
+                style={{
+                  borderColor: withAlpha(draftTheme.primaryColor, 0.25),
+                  backgroundColor: withAlpha(draftTheme.cardColor, 0.72),
+                  color: draftTheme.primaryColor,
+                }}
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                Vendor workspace
+              </div>
+              <h1 className="text-3xl font-bold tracking-tight text-slate-950 md:text-4xl">
+                Welcome back, {vendor?.name || user?.displayName || 'Vendor'}
+              </h1>
+              <p className="mt-3 max-w-xl text-sm leading-6 text-slate-600 md:text-base">
+                Track performance, manage your offers, and personalize the workspace to match your brand.
+              </p>
+            </div>
 
-      <div className="bg-white p-6 rounded-xl shadow-sm border">
-        <div className="flex justify-between items-center mb-6">
-          <h2 className="text-lg font-semibold">Revenue Overview</h2>
-          <select 
-            value={range} 
-            onChange={(e) => setRange(e.target.value as ChartRange)}
-            className="border p-2 rounded"
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/campaign"
+                className="inline-flex h-10 items-center gap-2 rounded-xl px-4 text-sm font-semibold shadow-sm transition hover:-translate-y-0.5"
+                style={{
+                  backgroundColor: draftTheme.primaryColor,
+                  color: primaryTextColor,
+                }}
+              >
+                Manage offers
+                <ArrowUpRight className="h-4 w-4" />
+              </Link>
+              <Link
+                to="/profile"
+                className="inline-flex h-10 items-center gap-2 rounded-xl border px-4 text-sm font-semibold text-slate-700 transition hover:-translate-y-0.5"
+                style={{
+                  backgroundColor: draftTheme.cardColor,
+                  borderColor: cardBorderColor,
+                }}
+              >
+                View profile
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {statCards.map(({ label, value, helper, icon: Icon }) => (
+            <article
+              key={label}
+              className="rounded-2xl border p-5 shadow-sm transition duration-200 hover:-translate-y-0.5 hover:shadow-md"
+              style={{
+                backgroundColor: draftTheme.cardColor,
+                borderColor: cardBorderColor,
+              }}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium text-slate-500">{label}</p>
+                  <p className="mt-2 text-2xl font-bold tracking-tight text-slate-950">
+                    {value}
+                  </p>
+                </div>
+                <div
+                  className="rounded-xl p-2.5"
+                  style={{
+                    backgroundColor: withAlpha(draftTheme.primaryColor, 0.1),
+                    color: draftTheme.primaryColor,
+                  }}
+                >
+                  <Icon className="h-5 w-5" />
+                </div>
+              </div>
+              <p className="mt-4 text-xs leading-5 text-slate-500">{helper}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="grid grid-cols-1 items-start gap-6 xl:grid-cols-[minmax(0,1.7fr)_minmax(320px,0.8fr)]">
+          <article
+            className="rounded-3xl border p-5 shadow-sm md:p-6"
+            style={{
+              backgroundColor: draftTheme.cardColor,
+              borderColor: cardBorderColor,
+            }}
           >
-            <option value="7d">Last 7 Days</option>
-            <option value="30d">Last 30 Days</option>
-            <option value="90d">Last 90 Days</option>
-          </select>
-        </div>
-        <div className="h-75">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={chartData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis />
-              <Tooltip />
-              <Area type="monotone" dataKey="revenue" stroke="#3b82f6" fill="#93c5fd" />
-            </AreaChart>
-          </ResponsiveContainer>
-        </div>
+            <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-bold text-slate-950">Revenue overview</h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  Completed transaction revenue over the selected period.
+                </p>
+              </div>
+              <div
+                className="inline-flex w-fit rounded-xl border p-1"
+                style={{ borderColor: cardBorderColor }}
+              >
+                {(['7d', '30d', '90d'] as ChartRange[]).map((option) => {
+                  const active = range === option
+                  return (
+                    <button
+                      key={option}
+                      type="button"
+                      onClick={() => setRange(option)}
+                      className="rounded-lg px-3 py-1.5 text-xs font-semibold transition"
+                      style={{
+                        backgroundColor: active ? draftTheme.primaryColor : 'transparent',
+                        color: active ? primaryTextColor : '#64748B',
+                      }}
+                    >
+                      {option === '7d' ? '7 days' : option === '30d' ? '30 days' : '90 days'}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className="h-80 w-full">
+              {hasRevenueData ? (
+                <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={chartData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                  <defs>
+                    <linearGradient id="vendorRevenueGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor={draftTheme.chartColor} stopOpacity={0.38} />
+                      <stop offset="100%" stopColor={draftTheme.chartColor} stopOpacity={0.03} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="4 4" stroke="#E2E8F0" vertical={false} />
+                  <XAxis
+                    dataKey="date"
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fill: '#64748B', fontSize: 12 }}
+                    tickFormatter={formatChartDate}
+                    minTickGap={24}
+                  />
+                  <YAxis
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fill: '#64748B', fontSize: 12 }}
+                    width={62}
+                  />
+                  <Tooltip
+                    labelFormatter={(label) => formatChartDate(String(label))}
+                    formatter={(value) => [formatCurrency(Number(value)), 'Revenue']}
+                    contentStyle={{
+                      borderRadius: 14,
+                      borderColor: cardBorderColor,
+                      boxShadow: '0 10px 30px rgba(15, 23, 42, 0.08)',
+                      backgroundColor: draftTheme.cardColor,
+                    }}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="revenue"
+                    stroke={draftTheme.chartColor}
+                    strokeWidth={3}
+                    fill="url(#vendorRevenueGradient)"
+                    activeDot={{ r: 5, fill: draftTheme.chartColor, strokeWidth: 0 }}
+                  />
+                </AreaChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex h-full items-center justify-center rounded-2xl border border-dashed border-slate-200 bg-slate-50/60">
+                  <div className="px-6 text-center">
+                    <p className="font-semibold text-slate-700">No revenue yet</p>
+                    <p className="mt-1 text-sm text-slate-500">
+                      Revenue activity will appear here after completed redemptions.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </article>
+
+          <aside
+            className="rounded-3xl border p-5 shadow-sm md:p-6"
+            style={{
+              backgroundColor: draftTheme.cardColor,
+              borderColor: cardBorderColor,
+            }}
+          >
+            <div className="flex items-start gap-3">
+              <div
+                className="rounded-xl p-2.5"
+                style={{
+                  backgroundColor: withAlpha(draftTheme.primaryColor, 0.1),
+                  color: draftTheme.primaryColor,
+                }}
+              >
+                <Palette className="h-5 w-5" />
+              </div>
+              <div>
+                <h2 className="text-lg font-bold text-slate-950">Customize dashboard</h2>
+                <p className="mt-1 text-sm leading-5 text-slate-500">
+                  Choose a palette or fine-tune individual colors. Changes preview instantly.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-6 grid grid-cols-2 gap-3">
+              {VENDOR_DASHBOARD_PALETTES.map((palette) => {
+                const active = themesMatch(draftTheme, palette.theme)
+                return (
+                  <button
+                    key={palette.name}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => setDraftTheme({ ...palette.theme })}
+                    className="rounded-2xl border p-3 text-left transition hover:-translate-y-0.5 hover:shadow-sm"
+                    style={{
+                      borderColor: active ? palette.theme.primaryColor : '#E2E8F0',
+                      boxShadow: active
+                        ? `0 0 0 2px ${withAlpha(palette.theme.primaryColor, 0.16)}`
+                        : undefined,
+                    }}
+                  >
+                    <div className="mb-3 flex gap-1.5">
+                      <span
+                        className="h-5 flex-1 rounded-md"
+                        style={{ backgroundColor: palette.theme.primaryColor }}
+                      />
+                      <span
+                        className="h-5 flex-1 rounded-md"
+                        style={{ backgroundColor: palette.theme.accentColor }}
+                      />
+                      <span
+                        className="h-5 flex-1 rounded-md border"
+                        style={{ backgroundColor: palette.theme.backgroundColor }}
+                      />
+                    </div>
+                    <p className="text-xs font-semibold text-slate-800">{palette.name}</p>
+                    <p className="mt-0.5 text-[11px] text-slate-500">{palette.description}</p>
+                  </button>
+                )
+              })}
+            </div>
+
+            <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+              <ColorField
+                label="Primary"
+                value={draftTheme.primaryColor}
+                onChange={(primaryColor) =>
+                  setDraftTheme((current) => ({ ...current, primaryColor }))
+                }
+              />
+              <ColorField
+                label="Accent"
+                value={draftTheme.accentColor}
+                onChange={(accentColor) =>
+                  setDraftTheme((current) => ({ ...current, accentColor }))
+                }
+              />
+              <ColorField
+                label="Chart"
+                value={draftTheme.chartColor}
+                onChange={(chartColor) =>
+                  setDraftTheme((current) => ({ ...current, chartColor }))
+                }
+              />
+            </div>
+
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row xl:flex-col 2xl:flex-row">
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1 gap-2 rounded-xl"
+                disabled={saveThemeMutation.isPending}
+                onClick={() => {
+                  setDraftTheme(DEFAULT_VENDOR_DASHBOARD_THEME)
+                  saveThemeMutation.mutate(DEFAULT_VENDOR_DASHBOARD_THEME)
+                }}
+              >
+                <RotateCcw className="h-4 w-4" />
+                Reset defaults
+              </Button>
+              <Button
+                type="button"
+                className="flex-1 gap-2 rounded-xl"
+                disabled={!hasUnsavedChanges || saveThemeMutation.isPending}
+                onClick={() => saveThemeMutation.mutate(draftTheme)}
+                style={{
+                  backgroundColor: draftTheme.primaryColor,
+                  color: primaryTextColor,
+                }}
+              >
+                {saveThemeMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                Save style
+              </Button>
+            </div>
+          </aside>
+        </section>
+
+        <section
+          className="rounded-3xl border p-5 shadow-sm md:p-6"
+          style={{
+            backgroundColor: draftTheme.cardColor,
+            borderColor: cardBorderColor,
+          }}
+        >
+          <div className="mb-5 flex items-center gap-3">
+            <div
+              className="rounded-xl p-2.5"
+              style={{
+                backgroundColor: withAlpha(draftTheme.accentColor, 0.12),
+                color: draftTheme.primaryColor,
+              }}
+            >
+              <Store className="h-5 w-5" />
+            </div>
+            <div>
+              <h2 className="text-lg font-bold text-slate-950">Quick actions</h2>
+              <p className="text-sm text-slate-500">Jump to the tools you use most.</p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <QuickAction
+              to="/campaign"
+              title="Manage offers"
+              description="Review active promotions and campaign details."
+              icon={BadgePercent}
+              color={draftTheme.primaryColor}
+            />
+            <QuickAction
+              to="/transaction-history"
+              title="Transaction history"
+              description="Review recent redemptions and transaction activity."
+              icon={ReceiptText}
+              color={draftTheme.primaryColor}
+            />
+            <QuickAction
+              to="/profile"
+              title="Business profile"
+              description="Check how your vendor information appears."
+              icon={Store}
+              color={draftTheme.primaryColor}
+            />
+          </div>
+        </section>
       </div>
     </div>
+  )
+}
+
+function ColorField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <label className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 px-3 py-2.5">
+      <span>
+        <span className="block text-xs font-semibold text-slate-700">{label}</span>
+        <span className="mt-0.5 block font-mono text-[10px] text-slate-400">{value}</span>
+      </span>
+      <input
+        type="color"
+        value={value}
+        onChange={(event) => onChange(event.target.value.toUpperCase())}
+        className="h-9 w-11 cursor-pointer rounded-lg border-0 bg-transparent p-0"
+        aria-label={`${label} color`}
+      />
+    </label>
+  )
+}
+
+function QuickAction({
+  to,
+  title,
+  description,
+  icon: Icon,
+  color,
+}: {
+  to: '/campaign' | '/transaction-history' | '/profile'
+  title: string
+  description: string
+  icon: typeof Store
+  color: string
+}) {
+  return (
+    <Link
+      to={to}
+      className="group flex items-start gap-3 rounded-2xl border border-slate-200 p-4 transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-sm"
+    >
+      <div
+        className="rounded-xl p-2.5"
+        style={{ backgroundColor: withAlpha(color, 0.1), color }}
+      >
+        <Icon className="h-5 w-5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-sm font-semibold text-slate-900">{title}</h3>
+          <ArrowUpRight className="h-4 w-4 text-slate-400 transition group-hover:text-slate-700" />
+        </div>
+        <p className="mt-1 text-xs leading-5 text-slate-500">{description}</p>
+      </div>
+    </Link>
   )
 }

--- a/src/routes/(vendor-panel)/_vendor.profile.tsx
+++ b/src/routes/(vendor-panel)/_vendor.profile.tsx
@@ -1,81 +1,508 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, Link } from '@tanstack/react-router'
 import { useQuery } from '@tanstack/react-query'
-import { vendorQueryOptions } from '@/queries'
+import type { ComponentType } from 'react'
+import {
+  ArrowUpRight,
+  BadgeCheck,
+  Building2,
+  ExternalLink,
+  Globe2,
+  Loader2,
+  Mail,
+  MapPin,
+  Phone,
+  Store,
+  Tags,
+  TicketCheck,
+} from 'lucide-react'
 import { useAuth } from '@/auth'
-import { Loader2 } from 'lucide-react'
+import { vendorQueryOptions } from '@/queries'
+import { vendorDashboardThemeQueryOptions } from '@/lib/vendor-dashboard-theme'
 
 export const Route = createFileRoute('/(vendor-panel)/_vendor/profile')({
   component: VendorProfile,
 })
 
+interface DetailItemProps {
+  icon: ComponentType<{ className?: string }>
+  label: string
+  value?: string | number | null
+  href?: string
+  external?: boolean
+  accentColor: string
+}
+
+function withAlpha(hexColor: string, alpha: number) {
+  const hex = hexColor.replace('#', '')
+  if (!/^[0-9A-Fa-f]{6}$/.test(hex)) return `rgba(15, 23, 42, ${alpha})`
+
+  const red = Number.parseInt(hex.slice(0, 2), 16)
+  const green = Number.parseInt(hex.slice(2, 4), 16)
+  const blue = Number.parseInt(hex.slice(4, 6), 16)
+
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+}
+
+function normalizeWebsite(value?: string) {
+  if (!value) return undefined
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`
+}
+
+function DetailItem({
+  icon: Icon,
+  label,
+  value,
+  href,
+  external = false,
+  accentColor,
+}: DetailItemProps) {
+  const content = value || 'Not provided'
+
+  return (
+    <div className="group flex min-h-24 items-start gap-3 rounded-2xl border border-slate-200/80 bg-white/75 p-4 transition hover:-translate-y-0.5 hover:shadow-sm">
+      <div
+        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl"
+        style={{
+          backgroundColor: withAlpha(accentColor, 0.12),
+          color: accentColor,
+        }}
+      >
+        <Icon className="h-5 w-5" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+          {label}
+        </p>
+
+        {href && value ? (
+          <a
+            href={href}
+            target={external ? '_blank' : undefined}
+            rel={external ? 'noreferrer' : undefined}
+            className="mt-1 flex items-center gap-1.5 break-words text-sm font-semibold text-slate-900 transition hover:opacity-70"
+          >
+            <span>{content}</span>
+            {external && <ExternalLink className="h-3.5 w-3.5 shrink-0" />}
+          </a>
+        ) : (
+          <p className={`mt-1 break-words text-sm font-semibold ${value ? 'text-slate-900' : 'text-slate-400'}`}>
+            {content}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function VendorProfile() {
   const { user } = useAuth()
   const vendorId = user?.uid || ''
 
-  const { data: vendor, isLoading } = useQuery(vendorQueryOptions(vendorId))
+  const { data: vendor, isLoading: vendorLoading } = useQuery(vendorQueryOptions(vendorId))
+  const { data: theme, isLoading: themeLoading } = useQuery(
+    vendorDashboardThemeQueryOptions(vendorId),
+  )
 
-  if (isLoading) {
+  if (vendorLoading || themeLoading || !theme) {
     return (
-      <div className="flex h-64 items-center justify-center">
-        <Loader2 className="animate-spin" />
+      <div className="flex min-h-[70vh] items-center justify-center bg-slate-50">
+        <div className="flex items-center gap-3 rounded-2xl border bg-white px-6 py-4 shadow-sm">
+          <Loader2 className="h-5 w-5 animate-spin text-emerald-500" />
+          <span className="font-medium text-slate-600">Preparing your profile...</span>
+        </div>
       </div>
     )
   }
 
   if (!vendor) {
-    return <div className="p-6">Vendor profile not found.</div>
+    return (
+      <div className="flex min-h-[70vh] items-center justify-center p-6">
+        <div className="max-w-md rounded-3xl border border-red-100 bg-red-50 p-8 text-center">
+          <Store className="mx-auto h-10 w-10 text-red-500" />
+          <h1 className="mt-4 text-xl font-bold text-slate-900">Vendor profile not found</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            We could not load the business profile connected to this account.
+          </p>
+        </div>
+      </div>
+    )
   }
 
-  const info = [
-    ['Name', vendor.name],
-    ['Arabic Name', vendor.nameAr],
-    ['Email', vendor.email],
-    ['Phone', vendor.phoneNumber],
-    ['Website', vendor.website],
-    ['Status', vendor.status],
-    ['Vendor Type', vendor.vendorType],
-    ['Main Category', vendor.mainCategory],
-    ['Address', vendor.address],
-    ['Arabic Address', vendor.addressAr],
+  const websiteHref = normalizeWebsite(vendor.website)
+  const offersCount = vendor.offers?.length || 0
+  const locationsCount = vendor.locations?.length || (vendor.address ? 1 : 0)
+  const subcategories = Array.isArray(vendor.subcategory) ? vendor.subcategory : []
+  const tags = [...(vendor.tagsEn || []), ...(vendor.tagsAr || [])]
+  const statusActive = vendor.status === 'Active'
+
+  const summaryCards = [
+    {
+      label: 'Active offers',
+      value: offersCount,
+      icon: TicketCheck,
+    },
+    {
+      label: 'Locations',
+      value: locationsCount,
+      icon: MapPin,
+    },
+    {
+      label: 'Categories',
+      value: 1 + subcategories.length,
+      icon: Tags,
+    },
   ]
 
   return (
-    <div className="p-6 space-y-6">
-      <h1 className="text-2xl font-bold">Profile</h1>
+    <main
+      className="min-h-full px-4 py-5 transition-colors md:px-6 md:py-7 lg:px-8"
+      style={{ backgroundColor: theme.backgroundColor }}
+    >
+      <div className="mx-auto max-w-7xl space-y-6">
+        <section
+          className="overflow-hidden rounded-3xl border p-5 shadow-sm md:p-7"
+          style={{
+            borderColor: withAlpha(theme.primaryColor, 0.16),
+            background: `linear-gradient(135deg, ${withAlpha(theme.primaryColor, 0.15)} 0%, ${theme.cardColor} 62%, ${withAlpha(theme.accentColor, 0.08)} 100%)`,
+          }}
+        >
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex flex-col gap-5 sm:flex-row sm:items-center">
+              <div
+                className="flex h-28 w-28 shrink-0 items-center justify-center overflow-hidden rounded-3xl border-4 shadow-sm"
+                style={{
+                  borderColor: withAlpha(theme.primaryColor, 0.18),
+                  backgroundColor: theme.cardColor,
+                }}
+              >
+                {vendor.profilePicture ? (
+                  <img
+                    src={vendor.profilePicture}
+                    alt={vendor.name || 'Vendor logo'}
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <Store className="h-11 w-11" style={{ color: theme.primaryColor }} />
+                )}
+              </div>
 
-      <div className="rounded-xl border bg-white p-6 shadow-sm">
-        <div className="flex items-center gap-4">
-          {vendor.profilePicture ? (
-            <img
-              src={vendor.profilePicture}
-              alt={vendor.name || 'Vendor logo'}
-              className="h-20 w-20 rounded-xl object-cover border"
-            />
-          ) : (
-            <div className="flex h-20 w-20 items-center justify-center rounded-xl border bg-gray-100 text-sm text-gray-500">
-              No Logo
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold"
+                    style={{
+                      color: theme.primaryColor,
+                      backgroundColor: withAlpha(theme.primaryColor, 0.1),
+                    }}
+                  >
+                    <BadgeCheck className="h-3.5 w-3.5" />
+                    Business profile
+                  </span>
+
+                  <span
+                    className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                      statusActive
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'bg-slate-200 text-slate-600'
+                    }`}
+                  >
+                    {vendor.status || 'Status unavailable'}
+                  </span>
+                </div>
+
+                <h1 className="mt-3 break-words text-3xl font-black tracking-tight text-slate-950 md:text-4xl">
+                  {vendor.name || 'Unnamed vendor'}
+                </h1>
+
+                {vendor.nameAr && (
+                  <p className="mt-1 text-lg font-medium text-slate-500" dir="rtl">
+                    {vendor.nameAr}
+                  </p>
+                )}
+
+                <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600 md:text-base">
+                  {vendor.shortDescription ||
+                    'Review how your business information appears across the RealX vendor workspace.'}
+                </p>
+              </div>
             </div>
-          )}
 
-          <div>
-            <h2 className="text-xl font-semibold">{vendor.name || 'Unnamed Vendor'}</h2>
-            {vendor.nameAr && <p className="text-gray-500">{vendor.nameAr}</p>}
+            <div className="flex flex-wrap gap-3">
+              <Link
+                to="/dashboard"
+                className="inline-flex h-11 items-center gap-2 rounded-xl px-5 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                style={{ backgroundColor: theme.primaryColor }}
+              >
+                Dashboard
+                <ArrowUpRight className="h-4 w-4" />
+              </Link>
+
+              <Link
+                to="/campaign"
+                className="inline-flex h-11 items-center gap-2 rounded-xl border bg-white px-5 text-sm font-semibold text-slate-800 transition hover:-translate-y-0.5 hover:shadow-sm"
+                style={{ borderColor: withAlpha(theme.primaryColor, 0.2) }}
+              >
+                Manage offers
+              </Link>
+            </div>
           </div>
-        </div>
-      </div>
+        </section>
 
-      <div className="rounded-xl border bg-white p-6 shadow-sm">
-        <h2 className="mb-4 text-lg font-semibold">Vendor Information</h2>
-
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-          {info.map(([label, value]) => (
-            <div key={label} className="rounded-lg border p-4">
-              <p className="text-sm text-gray-500">{label}</p>
-              <p className="font-medium">{value || '-'}</p>
-            </div>
+        <section className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {summaryCards.map(({ label, value, icon: Icon }) => (
+            <article
+              key={label}
+              className="flex items-center gap-4 rounded-2xl border p-5 shadow-sm"
+              style={{
+                backgroundColor: theme.cardColor,
+                borderColor: withAlpha(theme.primaryColor, 0.14),
+              }}
+            >
+              <div
+                className="flex h-12 w-12 items-center justify-center rounded-2xl"
+                style={{
+                  backgroundColor: withAlpha(theme.accentColor, 0.12),
+                  color: theme.primaryColor,
+                }}
+              >
+                <Icon className="h-6 w-6" />
+              </div>
+              <div>
+                <p className="text-2xl font-black text-slate-950">{value}</p>
+                <p className="text-sm font-medium text-slate-500">{label}</p>
+              </div>
+            </article>
           ))}
-        </div>
+        </section>
+
+        <section className="grid grid-cols-1 items-start gap-6 xl:grid-cols-[1.25fr_0.75fr]">
+          <article
+            className="rounded-3xl border p-5 shadow-sm md:p-6"
+            style={{
+              backgroundColor: theme.cardColor,
+              borderColor: withAlpha(theme.primaryColor, 0.14),
+            }}
+          >
+            <div className="mb-5 flex items-center gap-3">
+              <div
+                className="flex h-11 w-11 items-center justify-center rounded-2xl"
+                style={{
+                  backgroundColor: withAlpha(theme.primaryColor, 0.1),
+                  color: theme.primaryColor,
+                }}
+              >
+                <Building2 className="h-5 w-5" />
+              </div>
+              <div>
+                <h2 className="text-xl font-black text-slate-950">Business information</h2>
+                <p className="text-sm text-slate-500">Core details connected to your vendor account.</p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <DetailItem
+                icon={Store}
+                label="Business name"
+                value={vendor.name}
+                accentColor={theme.primaryColor}
+              />
+              <DetailItem
+                icon={Store}
+                label="Arabic name"
+                value={vendor.nameAr}
+                accentColor={theme.primaryColor}
+              />
+              <DetailItem
+                icon={Tags}
+                label="Main category"
+                value={vendor.mainCategory}
+                accentColor={theme.primaryColor}
+              />
+              <DetailItem
+                icon={Building2}
+                label="Vendor type"
+                value={vendor.vendorType === 'online' ? 'Online vendor' : vendor.vendorType === 'in_store' ? 'In-store vendor' : undefined}
+                accentColor={theme.primaryColor}
+              />
+            </div>
+
+            <div className="mt-5">
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                Subcategories
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {subcategories.length > 0 ? (
+                  subcategories.map((subcategory) => (
+                    <span
+                      key={subcategory}
+                      className="rounded-full px-3 py-1.5 text-xs font-semibold"
+                      style={{
+                        color: theme.primaryColor,
+                        backgroundColor: withAlpha(theme.primaryColor, 0.1),
+                      }}
+                    >
+                      {subcategory}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-sm text-slate-400">No subcategories provided.</span>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-5">
+              <p className="mb-3 text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+                Search tags
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {tags.length > 0 ? (
+                  tags.map((tag, index) => (
+                    <span
+                      key={`${tag}-${index}`}
+                      className="rounded-full border px-3 py-1.5 text-xs font-medium text-slate-600"
+                      style={{ borderColor: withAlpha(theme.primaryColor, 0.16) }}
+                    >
+                      {tag}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-sm text-slate-400">No search tags provided.</span>
+                )}
+              </div>
+            </div>
+          </article>
+
+          <article
+            className="rounded-3xl border p-5 shadow-sm md:p-6"
+            style={{
+              backgroundColor: theme.cardColor,
+              borderColor: withAlpha(theme.primaryColor, 0.14),
+            }}
+          >
+            <div className="mb-5 flex items-center gap-3">
+              <div
+                className="flex h-11 w-11 items-center justify-center rounded-2xl"
+                style={{
+                  backgroundColor: withAlpha(theme.accentColor, 0.12),
+                  color: theme.primaryColor,
+                }}
+              >
+                <Mail className="h-5 w-5" />
+              </div>
+              <div>
+                <h2 className="text-xl font-black text-slate-950">Contact and presence</h2>
+                <p className="text-sm text-slate-500">How customers and RealX can reach your business.</p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <DetailItem
+                icon={Mail}
+                label="Email"
+                value={vendor.email}
+                href={vendor.email ? `mailto:${vendor.email}` : undefined}
+                accentColor={theme.primaryColor}
+              />
+              <DetailItem
+                icon={Phone}
+                label="Phone"
+                value={vendor.phoneNumber || vendor.contact}
+                href={vendor.phoneNumber ? `tel:${vendor.phoneNumber}` : undefined}
+                accentColor={theme.primaryColor}
+              />
+              <DetailItem
+                icon={Globe2}
+                label="Website"
+                value={vendor.website}
+                href={websiteHref}
+                external
+                accentColor={theme.primaryColor}
+              />
+              <DetailItem
+                icon={MapPin}
+                label="Primary address"
+                value={vendor.address}
+                accentColor={theme.primaryColor}
+              />
+            </div>
+          </article>
+        </section>
+
+        {vendor.locations && vendor.locations.length > 0 && (
+          <section
+            className="rounded-3xl border p-5 shadow-sm md:p-6"
+            style={{
+              backgroundColor: theme.cardColor,
+              borderColor: withAlpha(theme.primaryColor, 0.14),
+            }}
+          >
+            <div className="mb-5 flex items-center gap-3">
+              <div
+                className="flex h-11 w-11 items-center justify-center rounded-2xl"
+                style={{
+                  backgroundColor: withAlpha(theme.primaryColor, 0.1),
+                  color: theme.primaryColor,
+                }}
+              >
+                <MapPin className="h-5 w-5" />
+              </div>
+              <div>
+                <h2 className="text-xl font-black text-slate-950">Business locations</h2>
+                <p className="text-sm text-slate-500">Branches currently connected to this profile.</p>
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {vendor.locations.map((location) => (
+                <div
+                  key={location.id}
+                  className="rounded-2xl border border-slate-200/80 bg-white/70 p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-bold text-slate-900">
+                        {location.name || 'Unnamed branch'}
+                      </p>
+                      {location.nameAr && (
+                        <p className="mt-0.5 text-sm text-slate-500" dir="rtl">
+                          {location.nameAr}
+                        </p>
+                      )}
+                    </div>
+                    {location.isPrimary && (
+                      <span
+                        className="rounded-full px-2.5 py-1 text-[11px] font-semibold"
+                        style={{
+                          color: theme.primaryColor,
+                          backgroundColor: withAlpha(theme.primaryColor, 0.1),
+                        }}
+                      >
+                        Primary
+                      </span>
+                    )}
+                  </div>
+
+                  <p className="mt-3 text-sm leading-6 text-slate-500">
+                    {location.address || 'Address not provided'}
+                  </p>
+
+                  {location.phoneNumber && (
+                    <a
+                      href={`tel:${location.phoneNumber}`}
+                      className="mt-3 inline-flex items-center gap-2 text-sm font-semibold"
+                      style={{ color: theme.primaryColor }}
+                    >
+                      <Phone className="h-4 w-4" />
+                      {location.phoneNumber}
+                    </a>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
       </div>
-    </div>
+    </main>
   )
 }


### PR DESCRIPTION
## Summary

- Redesigned the vendor dashboard with cleaner cards, improved revenue states, and quick actions
- Added per-vendor color palettes and custom theme colors
- Saved vendor theme preferences securely in Firestore
- Redesigned the vendor profile to follow the selected theme
- Redesigned the campaign/offers page with themed offer cards and improved empty states

## Notes

- Vendors can only read and write their own dashboard theme document
- Existing vendor profile and offer data structures are reused